### PR TITLE
Conf: .load() Properties using a Reader, not an InputStream

### DIFF
--- a/src/main/java/org/sonarsource/scanner/cli/Conf.java
+++ b/src/main/java/org/sonarsource/scanner/cli/Conf.java
@@ -19,9 +19,9 @@
  */
 package org.sonarsource.scanner.cli;
 
-import java.io.FileInputStream;
 import java.io.IOException;
-import java.io.InputStream;
+import java.io.Reader;
+import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -208,9 +208,21 @@ class Conf {
   }
 
   private static Properties toProperties(Path file) {
-    Properties properties = new Properties();
-    try (InputStream in = new FileInputStream(file.toFile())) {
-      properties.load(in);
+    final Properties properties = new Properties();
+    /*
+     * We want to load property files using the platform's default encoding.
+     *
+     * Historically, Java has always expected property files to be encoded using
+     * ISO-8859-1, but in this day and age, this expectation is unreasonable.
+     *
+     * Fortunately, since Java 6, an additional .load() method exists on the
+     * Properties class which uses a Reader instead of an InputStream... We use
+     * that, and we rely on Charset#defaultCharset() to return the encoding of
+     * the current OS/JVM combination.
+     */
+    final Charset charset = Charset.defaultCharset();
+    try (final Reader reader = Files.newBufferedReader(file, charset)) {
+      properties.load(reader);
       // Trim properties
       for (String propKey : properties.stringPropertyNames()) {
         properties.setProperty(propKey, properties.getProperty(propKey).trim());


### PR DESCRIPTION
The expectation that property files be encoded in ISO-8859-1 is a relic of the
past which has no justification in this day and age. UTF-8 is used almost
everywhere for text, with a notable exception: Windows operating systems, which
still insist on their own encodings, or as they call it, codepages (cp850,
cp1252).

The saving grace here is that the Java platform is good enough to accurately
detect the encoding used by a given platform that we can make use of it, using
Charset.defaultCharset(); also, Properties can .load() from a Reader since Java
6.

Make use of it.