### PR TITLE
removed extraneous line/option from usage message

### DIFF
--- a/src/main/java/org/sonarsource/scanner/cli/Cli.java
+++ b/src/main/java/org/sonarsource/scanner/cli/Cli.java
@@ -125,6 +125,5 @@ class Cli {
     logger.info(" -h,--help             Display help information");
     logger.info(" -v,--version          Display version information");
     logger.info(" -X,--debug            Produce execution debug output");
-    logger.info(" -i,--interactive      Run interactively");
   }
 }


### PR DESCRIPTION
The option is not valid, so usage should not print it.

Signed-off-by: Alexei Znamensky <russoz@gmail.com>