### PR TITLE
Improve assembly

### DIFF
--- a/src/main/assembly/bin/sonar-scanner
+++ b/src/main/assembly/bin/sonar-scanner
@@ -46,7 +46,7 @@ fi
 
 use_embedded_jre=${use_embedded_jre}
 if [ "$use_embedded_jre" = true ]; then
-  export JAVA_HOME=$sonar_scanner_home/lib/jre
+  export JAVA_HOME=$sonar_scanner_home/jre
 fi
 
 if [ -n "$JAVA_HOME" ]

--- a/src/main/assembly/bin/sonar-scanner.bat
+++ b/src/main/assembly/bin/sonar-scanner.bat
@@ -20,7 +20,7 @@ set SONAR_SCANNER_HOME=%~dp0..
 
 set use_embedded_jre=${use_embedded_jre}
 if "%use_embedded_jre%" == "true" (
-  set JAVA_HOME=%SONAR_SCANNER_HOME%\lib\jre
+  set JAVA_HOME=%SONAR_SCANNER_HOME%\jre
 )
 
 if not "%JAVA_HOME%" == "" goto foundJavaHome

--- a/src/main/assembly/dist-linux.xml
+++ b/src/main/assembly/dist-linux.xml
@@ -10,7 +10,7 @@
     <!-- jre basic, except bin/ -->
     <fileSet>
       <directory>${unpack.dir}/linux/${jre.dirname.linux}</directory>
-      <outputDirectory>lib/jre</outputDirectory>
+      <outputDirectory>jre</outputDirectory>
       <excludes>
         <exclude>bin/**</exclude>
         <exclude>man/**</exclude>
@@ -21,7 +21,7 @@
     <!-- jre bin/java -->
     <fileSet>
       <directory>${unpack.dir}/linux/${jre.dirname.linux}/bin</directory>
-      <outputDirectory>lib/jre/bin</outputDirectory>
+      <outputDirectory>jre/bin</outputDirectory>
       <includes>
         <include>java</include>
       </includes>

--- a/src/main/assembly/dist-macosx.xml
+++ b/src/main/assembly/dist-macosx.xml
@@ -7,13 +7,14 @@
   <baseDirectory>sonar-scanner-${project.version}-macosx</baseDirectory>
   <fileSets>
 
-    <!-- jre basic, except bin/ -->
+    <!-- jre basic, except bin/ and misc -->
     <fileSet>
       <directory>${unpack.dir}/macosx/${jre.dirname.macosx}</directory>
       <outputDirectory>lib/jre</outputDirectory>
       <excludes>
         <exclude>bin/**</exclude>
         <exclude>man/**</exclude>
+        <exclude>lib/jspawnhelper</exclude>
       </excludes>
     </fileSet>
 
@@ -23,6 +24,16 @@
       <outputDirectory>lib/jre/bin</outputDirectory>
       <includes>
         <include>java</include>
+      </includes>
+      <fileMode>0755</fileMode>
+    </fileSet>
+
+    <!-- jre lib executable files -->
+    <fileSet>
+      <directory>${unpack.dir}/macosx/${jre.dirname.macosx}/lib</directory>
+      <outputDirectory>lib/jre/lib</outputDirectory>
+      <includes>
+        <include>jspawnhelper</include>
       </includes>
       <fileMode>0755</fileMode>
     </fileSet>

--- a/src/main/assembly/dist-macosx.xml
+++ b/src/main/assembly/dist-macosx.xml
@@ -10,7 +10,7 @@
     <!-- jre basic, except bin/ and misc -->
     <fileSet>
       <directory>${unpack.dir}/macosx/${jre.dirname.macosx}</directory>
-      <outputDirectory>lib/jre</outputDirectory>
+      <outputDirectory>jre</outputDirectory>
       <excludes>
         <exclude>bin/**</exclude>
         <exclude>man/**</exclude>
@@ -21,7 +21,7 @@
     <!-- jre bin/java -->
     <fileSet>
       <directory>${unpack.dir}/macosx/${jre.dirname.macosx}/bin</directory>
-      <outputDirectory>lib/jre/bin</outputDirectory>
+      <outputDirectory>jre/bin</outputDirectory>
       <includes>
         <include>java</include>
       </includes>
@@ -31,7 +31,7 @@
     <!-- jre lib executable files -->
     <fileSet>
       <directory>${unpack.dir}/macosx/${jre.dirname.macosx}/lib</directory>
-      <outputDirectory>lib/jre/lib</outputDirectory>
+      <outputDirectory>jre/lib</outputDirectory>
       <includes>
         <include>jspawnhelper</include>
       </includes>

--- a/src/main/assembly/dist-windows.xml
+++ b/src/main/assembly/dist-windows.xml
@@ -10,7 +10,7 @@
     <!-- jre basic, except bin/ -->
     <fileSet>
       <directory>${unpack.dir}/windows/${jre.dirname.windows}</directory>
-      <outputDirectory>lib/jre</outputDirectory>
+      <outputDirectory>jre</outputDirectory>
       <excludes>
         <exclude>bin/**</exclude>
         <exclude>man/**</exclude>
@@ -21,7 +21,7 @@
     <!-- jre bin -->
     <fileSet>
       <directory>${unpack.dir}/windows/${jre.dirname.windows}/bin</directory>
-      <outputDirectory>lib/jre/bin</outputDirectory>
+      <outputDirectory>jre/bin</outputDirectory>
       <fileMode>0755</fileMode>
     </fileSet>
 


### PR DESCRIPTION
- Make `lib/jspawnhelper` executable for macosx
- Move `/lib/jre` to `/jre`