### PR TITLE
Wrap Windows ENV variables in quotes

### DIFF
--- a/src/main/assembly/bin/sonar-scanner.bat
+++ b/src/main/assembly/bin/sonar-scanner.bat
@@ -20,7 +20,7 @@ set SONAR_SCANNER_HOME=%~dp0..
 
 set use_embedded_jre=${use_embedded_jre}
 if "%use_embedded_jre%" == "true" (
-  set JAVA_HOME=%SONAR_SCANNER_HOME%\jre
+  set JAVA_HOME="%SONAR_SCANNER_HOME%"\jre
 )
 
 if not "%JAVA_HOME%" == "" goto foundJavaHome


### PR DESCRIPTION
Avoid Windows errors when using ENV variables with spaces in the path by wrapping `%SONAR_SCANNER_HOME%` in quotes.

Fixes the error in Windows Jenkins with:
> \Jenkins\tools\hudson.plugins.sonar.SonarRunnerInstallation\SonarQube_Scanner\bin\..\jre was unexpected at this time.
