### PR TITLE
remove trailing backslash from project.home

### DIFF
--- a/src/main/assembly/bin/sonar-scanner.bat
+++ b/src/main/assembly/bin/sonar-scanner.bat
@@ -65,6 +65,9 @@ goto run
 
 set PROJECT_HOME=%CD%
 
+@REM remove trailing backslash, see https://groups.google.com/d/msg/sonarqube/wi7u-CyV_tc/3u9UKRmABQAJ
+IF %PROJECT_HOME:~-1% == \ SET PROJECT_HOME=%PROJECT_HOME:~0,-1%
+
 %JAVA_EXEC% -Djava.awt.headless=true %SONAR_SCANNER_DEBUG_OPTS% %SONAR_SCANNER_OPTS% -cp "%SONAR_SCANNER_HOME%\lib\sonar-scanner-cli-${project.version}.jar" "-Dscanner.home=%SONAR_SCANNER_HOME%" "-Dproject.home=%PROJECT_HOME%" org.sonarsource.scanner.cli.Main %*
 if ERRORLEVEL 1 goto error
 goto end


### PR DESCRIPTION
We're using your scanner (https://docs.sonarqube.org/display/SCAN/Analyzing+with+SonarQube+Scanner+for+MSBuild) in a docker image and mounting the build directory under a virtual drive called W:. (because of npm/yarn issues with container mapped directories under windows containers, see https://github.com/nodejs/node/issues/8897#issuecomment-298662512).

When executing SonarQube.Scanner.MSBuild.exe end in W:\ the java process stops with:

```
C:\ProgramData\chocolatey\lib\msbuild-sonarqube-runner\tools\sonar-scanner-3.0.1.733\bin\..
Usage: java [-options] class [args...]
```

Removing the trailing backslash from W:\ fixes it.