### PR TITLE
Feature/improve logging

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+# editorconfig.org
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+max_line_length = 80
+indent_style = space
+indent_size = 2

--- a/src/main/java/org/sonarsource/scanner/cli/Cli.java
+++ b/src/main/java/org/sonarsource/scanner/cli/Cli.java
@@ -79,7 +79,17 @@ class Cli {
     } else if (asList("-X", "--debug").contains(arg)) {
       props.setProperty("sonar.verbose", "true");
       debugEnabled = true;
-      logger.setDebugEnabled(true);
+      logger.setLogLevel(Logs.LogLevel.DEBUG);
+      logger.setShowTimestamp(true);
+
+    } else if (arg.startsWith("-l") || arg.startsWith("--loglevel")) {
+      String logLevelStr = arg.substring(arg.split("\\s")[0].length()).trim();
+      try {
+        logger.setLogLevel(Logs.LogLevel.valueOf(logLevelStr));
+      } catch (IllegalArgumentException e) {
+        logger.info("'" + logLevelStr + "' is not a supported loglevel");
+        exit.exit(Exit.ERROR);
+      }
 
     } else if (asList("-D", "--define").contains(arg)) {
       return processProp(args, pos);
@@ -137,6 +147,7 @@ class Cli {
     logger.info("Options:");
     logger.info(" -D,--define <arg>     Define property");
     logger.info(" -h,--help             Display help information");
+    logger.info(" -l, --loglevel        Set the log level to: INFO, WARN, ERROR");
     logger.info(" -v,--version          Display version information");
     logger.info(" -X,--debug            Produce execution debug output");
   }

--- a/src/main/java/org/sonarsource/scanner/cli/Logs.java
+++ b/src/main/java/org/sonarsource/scanner/cli/Logs.java
@@ -25,42 +25,54 @@ import java.time.format.DateTimeFormatter;
 
 public class Logs {
   private DateTimeFormatter timeFormatter;
-  private boolean debugEnabled = false;
+  private boolean showTimestamp = false;
   private PrintStream stdOut;
   private PrintStream stdErr;
+  private LogLevel logLevel;
 
   public Logs(PrintStream stdOut, PrintStream stdErr) {
-    this.stdErr = stdErr;
+    this(stdOut, stdErr, LogLevel.INFO);
+  }
+
+  public Logs(PrintStream stdOut, PrintStream stdErr, LogLevel logLevel) {
     this.stdOut = stdOut;
+    this.stdErr = stdErr;
+    this.logLevel = logLevel;
     this.timeFormatter = DateTimeFormatter.ofPattern("HH:mm:ss.SSS");
   }
 
-  public void setDebugEnabled(boolean debugEnabled) {
-    this.debugEnabled = debugEnabled;
+  public void setShowTimestamp(boolean showTimestamp) {
+    this.showTimestamp = showTimestamp;
   }
 
-  public boolean isDebugEnabled() {
-    return debugEnabled;
+  public void setLogLevel(LogLevel logLevel) {
+    this.logLevel = logLevel;
   }
 
   public void debug(String message) {
-    if (isDebugEnabled()) {
+    if (logLevel.priority <= LogLevel.DEBUG.priority) {
       LocalTime currentTime = LocalTime.now();
       String timestamp = currentTime.format(timeFormatter);
-      stdOut.println(timestamp + " DEBUG: " + message);
+      stdOut.println(timestamp + " " + LogLevel.DEBUG.marker + ": " + message);
     }
   }
 
   public void info(String message) {
-    print(stdOut, "INFO: " + message);
+    if (logLevel.priority <= LogLevel.INFO.priority) {
+      print(stdOut, LogLevel.INFO.marker + ": " + message);
+    }
   }
 
   public void warn(String message) {
-    print(stdErr, "WARN: " + message);
+    if (logLevel.priority <= LogLevel.WARN.priority) {
+      print(stdErr, LogLevel.WARN.marker + ": " + message);
+    }
   }
 
   public void error(String message) {
-    print(stdErr, "ERROR: " + message);
+    if (logLevel.priority <= LogLevel.ERROR.priority) {
+      print(stdErr, LogLevel.ERROR.marker + ": " + message);
+    }
   }
 
   public void error(String message, Throwable t) {
@@ -69,12 +81,24 @@ public class Logs {
   }
 
   private void print(PrintStream stream, String msg) {
-    if (debugEnabled) {
+    if (showTimestamp) {
       LocalTime currentTime = LocalTime.now();
       String timestamp = currentTime.format(timeFormatter);
       stream.println(timestamp + " " + msg);
     } else {
       stream.println(msg);
+    }
+  }
+
+  public enum LogLevel {
+    DEBUG(2, "DEBUG"), INFO(3, "INFO"), WARN(4, "WARN"), ERROR(5, "ERROR");
+
+    private int priority;
+    private String marker;
+
+    LogLevel(int priority, String marker) {
+      this.priority = priority;
+      this.marker = marker;
     }
   }
 }

--- a/src/main/java/org/sonarsource/scanner/cli/Main.java
+++ b/src/main/java/org/sonarsource/scanner/cli/Main.java
@@ -103,7 +103,8 @@ public class Main {
     if ("true".equals(props.getProperty("sonar.verbose"))
       || "DEBUG".equalsIgnoreCase(props.getProperty("sonar.log.level"))
       || "TRACE".equalsIgnoreCase(props.getProperty("sonar.log.level"))) {
-      logger.setDebugEnabled(true);
+      logger.setLogLevel(Logs.LogLevel.DEBUG);
+      logger.setShowTimestamp(true);
     }
   }
 

--- a/src/test/java/org/sonarsource/scanner/cli/CliTest.java
+++ b/src/test/java/org/sonarsource/scanner/cli/CliTest.java
@@ -26,9 +26,9 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 public class CliTest {
-  Exit exit = mock(Exit.class);
-  Logs logs = new Logs(System.out, System.err);
-  Cli cli = new Cli(exit, logs);
+  private Exit exit = mock(Exit.class);
+  private Logs logs = new Logs(System.out, System.err);
+  private Cli cli = new Cli(exit, logs);
 
   @Test
   public void should_parse_empty_arguments() {
@@ -141,6 +141,30 @@ public class CliTest {
     cli.parse(new String[] {"-w"});
     verify(logs).error("Unrecognized option: -w");
     verify(logs).info("usage: sonar-scanner [options]");
+    verify(exit).exit(Exit.ERROR);
+  }
+
+  @Test
+  public void should_set_allowed_loglevel_with_l_parameter_correctly() {
+    logs = mock(Logs.class);
+    cli = new Cli(exit, logs);
+    cli.parse(new String[]{"-l INFO"});
+    verify(logs).setLogLevel(Logs.LogLevel.INFO);
+  }
+
+  @Test
+  public void should_set_allowed_loglevel_with_loglevel_parameter_correctly() {
+    logs = mock(Logs.class);
+    cli = new Cli(exit, logs);
+    cli.parse(new String[]{"--loglevel ERROR"});
+    verify(logs).setLogLevel(Logs.LogLevel.ERROR);
+  }
+
+  @Test
+  public void should_exit_with_error_if_loglevel_is_unknown() {
+    logs = mock(Logs.class);
+    cli = new Cli(exit, logs);
+    cli.parse(new String[]{"--loglevel UNKNOWN"});
     verify(exit).exit(Exit.ERROR);
   }
 }

--- a/src/test/java/org/sonarsource/scanner/cli/LogsTest.java
+++ b/src/test/java/org/sonarsource/scanner/cli/LogsTest.java
@@ -21,14 +21,13 @@ package org.sonarsource.scanner.cli;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Matchers;
+import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.sonarsource.scanner.cli.Logs;
+
 import java.io.PrintStream;
 
-import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 public class LogsTest {
   @Mock
@@ -51,19 +50,19 @@ public class LogsTest {
     verify(stdOut).println("INFO: info");
     verifyNoMoreInteractions(stdOut, stdErr);
   }
-  
+
   @Test
   public void testWarn() {
     logs.warn("warn");
     verify(stdErr).println("WARN: warn");
     verifyNoMoreInteractions(stdOut, stdErr);
   }
-  
+
   @Test
   public void testWarnWithTimestamp() {
-    logs.setDebugEnabled(true);
+    logs.setShowTimestamp(true);
     logs.warn("warn");
-    verify(stdErr).println(Matchers.matches("\\d\\d:\\d\\d:\\d\\d.\\d\\d\\d WARN: warn"));
+    verify(stdErr).println(ArgumentMatchers.matches("\\d\\d:\\d\\d:\\d\\d.\\d\\d\\d WARN: warn"));
     verifyNoMoreInteractions(stdOut, stdErr);
   }
 
@@ -80,14 +79,25 @@ public class LogsTest {
   }
 
   @Test
-  public void testDebug() {
-    logs.setDebugEnabled(true);
+  public void should_show_timestamp_if_enabled() {
+    logs.setLogLevel(Logs.LogLevel.DEBUG);
+    logs.setShowTimestamp(true);
 
     logs.debug("debug");
-    verify(stdOut).println(Matchers.matches("\\d\\d:\\d\\d:\\d\\d.\\d\\d\\d DEBUG: debug$"));
+    verify(stdOut).println(ArgumentMatchers.matches("\\d\\d:\\d\\d:\\d\\d.\\d\\d\\d DEBUG: debug$"));
+  }
 
-    logs.setDebugEnabled(false);
-    logs.debug("debug");
-    verifyNoMoreInteractions(stdOut, stdErr);
+  @Test
+  public void should_not_print_info_if_loglevel_is_warn() {
+    logs.setLogLevel(Logs.LogLevel.WARN);
+    logs.info("some information");
+    verifyZeroInteractions(stdErr);
+  }
+
+  @Test
+  public void should_not_print_warn_if_loglevel_is_error() {
+    logs.setLogLevel(Logs.LogLevel.ERROR);
+    logs.warn("warn");
+    verifyZeroInteractions(stdErr);
   }
 }

--- a/src/test/java/org/sonarsource/scanner/cli/MainTest.java
+++ b/src/test/java/org/sonarsource/scanner/cli/MainTest.java
@@ -60,7 +60,7 @@ public class MainTest {
   private Logs logs;
 
   @Before
-  public void setUp() throws IOException {
+  public void setUp() {
     MockitoAnnotations.initMocks(this);
     when(scannerFactory.create(any(Properties.class))).thenReturn(scanner);
     when(conf.properties()).thenReturn(properties);
@@ -120,7 +120,7 @@ public class MainTest {
     verify(logs).error("Caused by: NPE");
     verify(logs).error("Re-run SonarQube Scanner using the -X switch to enable full debug logging.");
   }
-  
+
   @Test
   public void show_error_MessageException_debug() {
     Exception e = createException(true);
@@ -165,7 +165,7 @@ public class MainTest {
   }
 
   @Test
-  public void should_only_display_version() throws IOException {
+  public void should_only_display_version() {
 
     Properties p = new Properties();
     when(cli.isDisplayVersionOnly()).thenReturn(true);
@@ -182,7 +182,7 @@ public class MainTest {
   }
 
   @Test
-  public void should_skip() throws IOException {
+  public void should_skip() {
     Properties p = new Properties();
     p.setProperty(ScanProperties.SKIP, "true");
     when(conf.properties()).thenReturn(p);
@@ -199,7 +199,7 @@ public class MainTest {
   }
 
   @Test
-  public void shouldLogServerVersion() throws IOException {
+  public void shouldLogServerVersion() {
     when(scanner.serverVersion()).thenReturn("5.5");
     Properties p = new Properties();
     when(cli.isDisplayVersionOnly()).thenReturn(true);
@@ -211,24 +211,24 @@ public class MainTest {
   }
 
   @Test
-  public void should_configure_logging() throws IOException {
+  public void should_configure_logging() {
     Properties analysisProps = testLogging("sonar.verbose", "true");
     assertThat(analysisProps.getProperty("sonar.verbose")).isEqualTo("true");
   }
 
   @Test
-  public void should_configure_logging_trace() throws IOException {
+  public void should_configure_logging_trace() {
     Properties analysisProps = testLogging("sonar.log.level", "TRACE");
     assertThat(analysisProps.getProperty("sonar.log.level")).isEqualTo("TRACE");
   }
 
   @Test
-  public void should_configure_logging_debug() throws IOException {
+  public void should_configure_logging_debug() {
     Properties analysisProps = testLogging("sonar.log.level", "DEBUG");
     assertThat(analysisProps.getProperty("sonar.log.level")).isEqualTo("DEBUG");
   }
 
-  private Properties testLogging(String propKey, String propValue) throws IOException {
+  private Properties testLogging(String propKey, String propValue) {
     Properties p = new Properties();
     p.put(propKey, propValue);
     when(conf.properties()).thenReturn(p);
@@ -237,7 +237,7 @@ public class MainTest {
     main.execute();
 
     // Logger used for callback should have debug enabled
-    verify(logs).setDebugEnabled(true);
+    verify(logs).setShowTimestamp(true);
 
     ArgumentCaptor<Properties> propertiesCapture = ArgumentCaptor.forClass(Properties.class);
     verify(scanner).execute((Map) propertiesCapture.capture());


### PR DESCRIPTION
Allowing loglevels to be set as parameter (-l, --loglevel) and respect them. Also, separating the concern of (not) showing a timestamp within the log seems useful.