### PR TITLE
Check if Java is installed on Linux

### DIFF
--- a/src/main/assembly/bin/sonar-scanner
+++ b/src/main/assembly/bin/sonar-scanner
@@ -49,6 +49,11 @@ else
   java_cmd="$(which java)"
 fi
 
+if [ -z "$java_cmd" -o ! -x "$java_cmd" ] ; then
+  echo "Could not find 'java' executable in JAVA_HOME or PATH."
+  exit 1
+fi
+
 project_home=$(pwd)
 
 #echo "Info: Using sonar-scanner at $sonar_scanner_home"


### PR DESCRIPTION
We have some Jenkins slaves that has no Java installed. It was a bit hard to find out what was wrong as only a 
`/home/jenkins/tools/hudson.plugins.sonar.SonarRunnerInstallation/sonar/bin/sonar-scanner: 59: exec: : Permission denied`
message was shown