### PR TITLE
chore: added docker image for scanner

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM openjdk:8-jre-alpine
+
+LABEL maintainer="nanaflat <nanoflat@gmail.com>"
+
+ARG SONAR_SCANNER_VERSION
+
+RUN apk add --no-cache curl sed unzip nodejs yarn
+
+# Settings
+ENV SONAR_URL="https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-${SONAR_SCANNER_VERSION}-linux.zip"
+ENV SONAR_RUNNER_HOME="/sonar-scanner-${SONAR_SCANNER_VERSION}-linux"
+ENV PATH $PATH:$SONAR_RUNNER_HOME/bin
+
+# Install sonar-scanner
+RUN curl -o ./sonarscanner.zip -L $SONAR_URL
+RUN unzip sonarscanner.zip 
+RUN rm sonarscanner.zip
+
+# Ensure Sonar Scanner uses openjdk instead of the packaged JRE (which is broken)
+RUN sed -i 's/use_embedded_jre=true/use_embedded_jre=false/g' $SONAR_RUNNER_HOME/bin/sonar-scanner

--- a/docker_build.sh
+++ b/docker_build.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+#assume latest version from tag
+SONAR_SCANNER_VERSION=$(git describe --tags |cut -d- -f1)
+echo Scanner version is ${SONAR_SCANNER_VERSION}
+
+#build docker image
+docker build \
+      --pull \
+      --build-arg SONAR_SCANNER_VERSION="${SONAR_SCANNER_VERSION}" \
+      -t "${DOCKERHUB_USERNAME}/sonar-scanner:${SONAR_SCANNER_VERSION}" \
+      -t "${DOCKERHUB_USERNAME}/sonar-scanner:latest" \
+      .
+
+#push docker image to dockerhub
+echo "$DOCKERHUB_PASSWORD" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
+docker push ${DOCKERHUB_USERNAME}/sonar-scanner


### PR DESCRIPTION

- [ ] Please explain your motives to contribute this change: what problem you are trying to fix, what improvement you are trying to make:

Sonar scanner is used in many projects and companies as part of CI/CD process, to simplify their life we can provide automated docker image of the scanner. There are plenty already but all of them are not official and supported.

It's WIP pull-request to start a discussion on how I can help to build this for the community.
questions to solve:
1) Building image from scanner CI (travis?), we need to add post-action on succeeded pipeline
2) Pushing image to official dockerhub of SonarSource, can be done in travis as well with secret vars for dockerhub credentials