### PR TITLE
include keytool in Mac & Linux bundles

### DIFF
--- a/src/main/assembly/dist-linux.xml
+++ b/src/main/assembly/dist-linux.xml
@@ -24,6 +24,7 @@
       <outputDirectory>jre/bin</outputDirectory>
       <includes>
         <include>java</include>
+        <include>keytool</include>
       </includes>
       <fileMode>0755</fileMode>
     </fileSet>

--- a/src/main/assembly/dist-macosx.xml
+++ b/src/main/assembly/dist-macosx.xml
@@ -24,6 +24,7 @@
       <outputDirectory>jre/bin</outputDirectory>
       <includes>
         <include>java</include>
+        <include>keytool</include>
       </includes>
       <fileMode>0755</fileMode>
     </fileSet>


### PR DESCRIPTION
As described in the [community](https://community.sonarsource.com/t/release-sonar-scanner-with-keytool-executable/17842) I would like to add certificates to the Java key store to connect to a Sonar Enterprise instance when running the Sonar-Scanner CLI Docker image. 

To do so the JRE is missing the `keytool` executable in the Mac and Linux bundle (Windows contains **all** `exe` files).

This PR adds the `keytool` to the list of bundled executables.