### PR TITLE
fix issue with whitespaces in sonar-scanner path

### DIFF
--- a/src/main/assembly/bin/sonar-scanner
+++ b/src/main/assembly/bin/sonar-scanner
@@ -39,7 +39,7 @@ fi
 
 use_embedded_jre=${use_embedded_jre}
 if [ "$use_embedded_jre" = true ]; then
-  export JAVA_HOME=$sonar_scanner_home/jre
+  export JAVA_HOME="$sonar_scanner_home/jre"
 fi
 
 if [ -n "$JAVA_HOME" ]


### PR DESCRIPTION
This fixes an issue where the `sonar-scanner` script fails in case the scanner is executed from a directory that contains whitespaces.

**steps to reproduce issue**:
- run sonar-scanner-cli Docker: `docker run -it --rm --entrypoint bash -v $(pwd):/home/scanner-cli/with\ whitespace --workdir=/home/scanner-cli/with\ whitespace sonarsource/sonar-scanner-cli`
-  copy sonar-scanner to path with whitespaces: `cp -r -p /opt/sonar-scanner/ .`
- execute `sonar-scanner`: `./sonar-scanner/bin/sonar-scanner`

The sonar-scanner fails with the following message which originates from the line changed in this PR:
```
./sonar-scanner/bin/sonar-scanner: 42: export: whitespace/sonar-scanner/jre: bad variable name
```