### PR TITLE
SQSCANNER-97 updated embedded JRE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,9 +48,9 @@
     <!-- configuration for assembly of distributions -->
     <unpack.dir>${project.build.directory}/unpack</unpack.dir>
     <scanner.jar>${project.build.finalName}.jar</scanner.jar>
-    <jre.dirname.linux>jdk-11.0.11+9-jre</jre.dirname.linux>
-    <jre.dirname.windows>jdk-11.0.11+9-jre</jre.dirname.windows>
-    <jre.dirname.macosx>jdk-11.0.11+9-jre/Contents/Home</jre.dirname.macosx>
+    <jre.dirname.linux>jdk-11.0.14.1+1-jre</jre.dirname.linux>
+    <jre.dirname.windows>jdk-11.0.14.1+1-jre</jre.dirname.windows>
+    <jre.dirname.macosx>jdk-11.0.14.1+1-jre/Contents/Home</jre.dirname.macosx>
 
     <!-- Release: enable publication to Bintray -->
     <artifactsToPublish>${project.groupId}:${project.artifactId}:zip,${project.groupId}:${project.artifactId}:zip:linux,${project.groupId}:${project.artifactId}:zip:windows,${project.groupId}:${project.artifactId}:zip:macosx</artifactsToPublish>
@@ -219,10 +219,10 @@
                   <goal>wget</goal>
                 </goals>
                 <configuration>
-                  <url>https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.11%2B9/OpenJDK11U-jre_x64_linux_hotspot_11.0.11_9.tar.gz</url>
+                  <url>https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.14.1%2B1/OpenJDK11U-jre_x64_linux_hotspot_11.0.14.1_1.tar.gz</url>
                   <unpack>true</unpack>
                   <outputDirectory>${unpack.dir}/linux</outputDirectory>
-                  <sha512>5b8c1c16c5faa467bbb35a1d1e694afc50b0c2dbbe77abb29620f30602187a1a903f60169e2b691dcc81b6d902ed5a17239318f27765f19351281209befb0e96</sha512>
+                  <sha256>b5a6960bc6bb0b1a967e307f908ea9b06ad7adbbd9df0b8954ab51374faa8a98</sha256>
                 </configuration>
               </execution>
             </executions>
@@ -269,10 +269,10 @@
                   <goal>wget</goal>
                 </goals>
                 <configuration>
-                  <url>https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.11%2B9/OpenJDK11U-jre_x64_windows_hotspot_11.0.11_9.zip</url>
+                  <url>https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.14.1%2B1/OpenJDK11U-jre_x64_windows_hotspot_11.0.14.1_1.zip</url>
                   <unpack>true</unpack>
                   <outputDirectory>${unpack.dir}/windows</outputDirectory>
-                  <sha512>a6e5290a9839d64e50d5a52cec6e821f6d7c2de9e42aca67cfef7e9dd75a51c597ceaf397ba7ed0e004c6299043d0c3c679357d31fd68b17e2d85ca3fb0abd6b</sha512>
+                  <sha256>49500200b482c407159e9907bb53efd2b2ad772623c3857c23c17c1304d421b5</sha256>
                 </configuration>
               </execution>
             </executions>
@@ -318,10 +318,10 @@
                   <goal>wget</goal>
                 </goals>
                 <configuration>
-                  <url>https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.11%2B9/OpenJDK11U-jre_x64_mac_hotspot_11.0.11_9.tar.gz</url>
+                  <url>https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.14.1%2B1/OpenJDK11U-jre_x64_mac_hotspot_11.0.14.1_1.tar.gz</url>
                   <unpack>true</unpack>
                   <outputDirectory>${unpack.dir}/macosx</outputDirectory>
-                  <sha512>2f9b2c2c7666e44c9212e71d343bf3e5ed980159cb75ec8b217e6e485efcdaff80f3e66efe1f7d91ffe475c792f0a3c38affeb91597561c575e9c7b5cc814b82</sha512>
+                  <sha256>1b2f792ad05af9dba876db962c189527e645b48f50ceb842b4e39169de553303</sha256>
                 </configuration>
               </execution>
             </executions>


### PR DESCRIPTION
sha256sums from https://github.com/adoptium/temurin11-binaries/releases/tag/jdk-11.0.14.1%2B1 
sadly they don't publish sha512sums 