### PR TITLE
Make jre/lib/jspawnhelper executable on linux

### DIFF
--- a/src/main/assembly/dist-linux.xml
+++ b/src/main/assembly/dist-linux.xml
@@ -14,6 +14,7 @@
       <excludes>
         <exclude>bin/**</exclude>
         <exclude>man/**</exclude>
+        <exclude>lib/jspawnhelper</exclude>
         <exclude>plugin/**</exclude>
       </excludes>
     </fileSet>
@@ -24,6 +25,16 @@
       <outputDirectory>jre/bin</outputDirectory>
       <includes>
         <include>java</include>
+      </includes>
+      <fileMode>0755</fileMode>
+    </fileSet>
+
+    <!-- jre lib executable files -->
+    <fileSet>
+      <directory>${unpack.dir}/linux/${jre.dirname.linux}/lib</directory>
+      <outputDirectory>jre/lib</outputDirectory>
+      <includes>
+        <include>jspawnhelper</include>
       </includes>
       <fileMode>0755</fileMode>
     </fileSet>


### PR DESCRIPTION
Ran into issue with using sonar-scanner using the embed java under Linux.
We are using C++ plugin to run the scanner.

```
ERROR: Error during SonarScanner execution
java.lang.IllegalStateException: java.io.IOException: Cannot run program "/usr/src/app/.scannerwork/.sonartmp/16117978935657518899/subprocess" (in directory "/usr/src/app/lib"): error=13, Permission denied
        at com.sonar.cpp.driver.ProcessExecutor.execute(ProcessExecutor.java:73)
        at com.sonar.cpp.driver.ProcessExecutor.execute(ProcessExecutor.java:44)
        at com.sonar.cpp.analyzer.ClangDriver.lambda$probeCompiler$9(ClangDriver.java:759)
        at java.base/java.util.HashMap.computeIfAbsent(Unknown Source)
        at com.sonar.cpp.analyzer.ClangDriver.probeCompiler(ClangDriver.java:749)
        at com.sonar.cpp.analyzer.ClangDriver.onCapture(ClangDriver.java:488)
        at com.sonar.cpp.analyzer.CompilerDrivers.onCapture(CompilerDrivers.java:34)
        at com.sonar.cpp.plugin.CFamilySensor.lambda$process$17(CFamilySensor.java:908)
        at com.sonar.cpp.plugin.BuildWrapperJsonReader.readCaptures(BuildWrapperJsonReader.java:86)
        at com.sonar.cpp.plugin.CFamilySensor.process(CFamilySensor.java:905)
        at com.sonar.cpp.plugin.CFamilySensor.process(CFamilySensor.java:410)
        at com.sonar.cpp.plugin.CFamilySensor.execute(CFamilySensor.java:215)
        at org.sonar.scanner.sensor.AbstractSensorWrapper.analyse(AbstractSensorWrapper.java:64)
        at org.sonar.scanner.sensor.ModuleSensorsExecutor.execute(ModuleSensorsExecutor.java:88)
        at org.sonar.scanner.sensor.ModuleSensorsExecutor.execute(ModuleSensorsExecutor.java:64)
        at org.sonar.scanner.scan.SpringModuleScanContainer.doAfterStart(SpringModuleScanContainer.java:82)
        at org.sonar.core.platform.SpringComponentContainer.startComponents(SpringComponentContainer.java:188)
        at org.sonar.core.platform.SpringComponentContainer.execute(SpringComponentContainer.java:167)
        at org.sonar.scanner.scan.SpringProjectScanContainer.scan(SpringProjectScanContainer.java:403)
        at org.sonar.scanner.scan.SpringProjectScanContainer.scanRecursively(SpringProjectScanContainer.java:399)
        at org.sonar.scanner.scan.SpringProjectScanContainer.doAfterStart(SpringProjectScanContainer.java:368)
        at org.sonar.core.platform.SpringComponentContainer.startComponents(SpringComponentContainer.java:188)
        at org.sonar.core.platform.SpringComponentContainer.execute(SpringComponentContainer.java:167)
        at org.sonar.scanner.bootstrap.SpringGlobalContainer.doAfterStart(SpringGlobalContainer.java:137)
        at org.sonar.core.platform.SpringComponentContainer.startComponents(SpringComponentContainer.java:188)
        at org.sonar.core.platform.SpringComponentContainer.execute(SpringComponentContainer.java:167)
        at org.sonar.batch.bootstrapper.Batch.doExecute(Batch.java:72)
        at org.sonar.batch.bootstrapper.Batch.execute(Batch.java:66)
        at org.sonarsource.scanner.api.internal.batch.BatchIsolatedLauncher.execute(BatchIsolatedLauncher.java:46)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(Unknown Source)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source)
        at java.base/java.lang.reflect.Method.invoke(Unknown Source)
        at org.sonarsource.scanner.api.internal.IsolatedLauncherProxy.invoke(IsolatedLauncherProxy.java:60)
        at jdk.proxy1/jdk.proxy1.$Proxy0.execute(Unknown Source)
        at org.sonarsource.scanner.api.EmbeddedScanner.doExecute(EmbeddedScanner.java:189)
        at org.sonarsource.scanner.api.EmbeddedScanner.execute(EmbeddedScanner.java:138)
        at org.sonarsource.scanner.cli.Main.execute(Main.java:126)
        at org.sonarsource.scanner.cli.Main.execute(Main.java:81)
        at org.sonarsource.scanner.cli.Main.main(Main.java:62)
Caused by: java.io.IOException: Cannot run program "/usr/src/app/.scannerwork/.sonartmp/16117978935657518899/subprocess" (in directory "/usr/src/app/lib"): error=13, Permission denied
        at java.base/java.lang.ProcessBuilder.start(Unknown Source)
        at java.base/java.lang.ProcessBuilder.start(Unknown Source)
        at com.sonar.cpp.driver.ProcessExecutor.execute(ProcessExecutor.java:57)
        ... 39 more
Caused by: java.io.IOException: error=13, Permission denied
        at java.base/java.lang.ProcessImpl.forkAndExec(Native Method)
        at java.base/java.lang.ProcessImpl.<init>(Unknown Source)
        at java.base/java.lang.ProcessImpl.start(Unknown Source)
        ... 42 more
```

After stracing, I found this in the strack output.
```
[pid   397] 1690852277.316501 execve("/opt/sonar-scanner/jre/lib/jspawnhelper", ["74:77"], 0x7ffd84db9018 /* 80 vars */) = -1 EACCES (Permission denied)
```

We started to see this version with 5.0. We did not have this issue under 4.8
```
sonar-scanner -v
INFO: SonarScanner 5.0.0.2966
```

I am applying the same permissions fixes that is done for macos.
https://github.com/SonarSource/sonar-scanner-cli/blob/69fff1fbace0f3f5f3955432dcfed2c7c22bf136/src/main/assembly/dist-macosx.xml#L31