### PR TITLE
SQSCANNER-124 Migrate away from FGC promote function

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -13,10 +13,8 @@ env:
   ARTIFACTORY_DEPLOY_USERNAME: vault-${CIRRUS_REPO_OWNER}-${CIRRUS_REPO_NAME}-qa-deployer
   ARTIFACTORY_DEPLOY_PASSWORD: VAULT[development/artifactory/token/SonarSource-sonar-scanner-cli-qa-deployer access_token]
   ARTIFACTORY_DEPLOY_REPO: sonarsource-public-qa
-
-  GCF_ACCESS_TOKEN: VAULT[development/kv/data/promote data.token]
-  PROMOTE_URL: VAULT[development/kv/data/promote data.url]
-
+  ARTIFACTORY_PROMOTE_ACCESS_TOKEN: VAULT[development/artifactory/token/${CIRRUS_REPO_OWNER}-${CIRRUS_REPO_NAME}-promoter access_token]
+  
   BURGR_URL: VAULT[development/kv/data/burgr data.url]
   BURGR_USERNAME: VAULT[development/kv/data/burgr data.cirrus_username]
   BURGR_PASSWORD: VAULT[development/kv/data/burgr data.cirrus_password]


### PR DESCRIPTION
Will drop build the warning `[WARN] Obsolete build promotion. The feature is marked for removal starting November 30, 2023.` by moving away from the Google Cloud function previously used to handle the build promotion

https://sonarsource.atlassian.net/browse/SQSCANNER-124