### PR TITLE
Bump JDK from `17.0.7+7` to `17.0.10+7`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,9 +52,9 @@
     <!-- configuration for assembly of distributions -->
     <unpack.dir>${project.build.directory}/unpack</unpack.dir>
     <scanner.jar>${project.build.finalName}.jar</scanner.jar>
-    <jre.dirname.linux>jdk-17.0.7+7-jre</jre.dirname.linux>
-    <jre.dirname.windows>jdk-17.0.7+7-jre</jre.dirname.windows>
-    <jre.dirname.macosx>jdk-17.0.7+7-jre/Contents/Home</jre.dirname.macosx>
+    <jre.dirname.linux>jdk-17.0.10+7-jre</jre.dirname.linux>
+    <jre.dirname.windows>jdk-17.0.10+7-jre</jre.dirname.windows>
+    <jre.dirname.macosx>jdk-17.0.10+7-jre/Contents/Home</jre.dirname.macosx>
 
     <!-- Release: enable publication to Bintray -->
     <artifactsToPublish>${project.groupId}:${project.artifactId}:zip,${project.groupId}:${project.artifactId}:zip:linux,${project.groupId}:${project.artifactId}:zip:windows,${project.groupId}:${project.artifactId}:zip:macosx,${project.groupId}:${project.artifactId}:json:cyclonedx</artifactsToPublish>
@@ -236,10 +236,10 @@
                   <goal>wget</goal>
                 </goals>
                 <configuration>
-                  <url>https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.7%2B7/OpenJDK17U-jre_x64_linux_hotspot_17.0.7_7.tar.gz</url>
+                  <url>https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.10%2B7/OpenJDK17U-jre_x64_linux_hotspot_17.0.10_7.tar.gz</url>
                   <unpack>true</unpack>
                   <outputDirectory>${unpack.dir}/linux</outputDirectory>
-                  <sha256>bb025133b96266f6415d5084bb9b260340a813968007f1d2d14690f20bd021ca</sha256>
+                  <sha256>620CC0E7338F2722F3ED076AC65C0FAFB575981426BAC4E1970860E5E2D048F0</sha256>
                 </configuration>
               </execution>
             </executions>
@@ -286,10 +286,10 @@
                   <goal>wget</goal>
                 </goals>
                 <configuration>
-                  <url>https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.7%2B7/OpenJDK17U-jre_x64_windows_hotspot_17.0.7_7.zip</url>
+                  <url>https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.10%2B7/OpenJDK17U-jre_x64_windows_hotspot_17.0.10_7.zip</url>
                   <unpack>true</unpack>
                   <outputDirectory>${unpack.dir}/windows</outputDirectory>
-                  <sha256>62e82c1afa7509424813e9cb22d8becfec4346d7505e6d2fc8770af4dcd5b9a0</sha256>
+                  <sha256>C67CECEAD5F837A4511619500ECA4AD1A2AD452CA377DFF910AB3536BD8B1CE9</sha256>
                 </configuration>
               </execution>
             </executions>
@@ -335,10 +335,10 @@
                   <goal>wget</goal>
                 </goals>
                 <configuration>
-                  <url>https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.7%2B7/OpenJDK17U-jre_x64_mac_hotspot_17.0.7_7.tar.gz</url>
+                  <url>https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.10%2B7/OpenJDK17U-jre_x64_mac_hotspot_17.0.10_7.tar.gz</url>
                   <unpack>true</unpack>
                   <outputDirectory>${unpack.dir}/macosx</outputDirectory>
-                  <sha256>62559a927a8dbac2ea1d7879f590a62fea87d61bfaa92894e578d2045b8d921b</sha256>
+                  <sha256>0227D3B890FA79A7F87F5610AB0EB6DBC6B87E943979E941DE06D4C89BC90329</sha256>
                 </configuration>
               </execution>
             </executions>


### PR DESCRIPTION
#### Please explain your motives to contribute this change: what problem you are trying to fix, what improvement you are trying to make

My team's analysers are flagging the CLI in containers because the version of the JDK shipped with the binary contains three high CVEs:
- CVE-2024-20952
- CVE-2024-20932
- CVE-2024-20918

A simple bump should address the issue. Note that the CLI still reports other vulnerabilities. For those, there already is an open PR: https://github.com/SonarSource/sonar-scanner-commons/pull/162

#### Use the following formatting style: [SonarSource/sonar-developer-toolset](https://github.com/SonarSource/sonar-developer-toolset#code-style)

N/A

#### Provide a unit test for any code you changed

N/A

####  If there is a [JIRA](http://jira.sonarsource.com/browse/SQSCANNER) ticket available, please make your commits and pull request start with the ticket ID (SQSCANNER-XXXX)

[No matching ticket found](https://sonarsource.atlassian.net/jira/software/c/projects/SQSCANNER/issues/SQSCANNER-117?jql=project%20%3D%20%22SQSCANNER%22%20AND%20text%20~%20%22jdk%22%20ORDER%20BY%20created%20DESC)
