### PR TITLE
BUILD-4839 Update the release workflow to the latest version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,32 +10,8 @@ jobs:
     permissions:
       id-token: write
       contents: write
-    uses: SonarSource/gh-action_release/.github/workflows/main.yaml@66a34c7817fc1684b80badc4326de58c334133de # 5.0.10
+    uses: SonarSource/gh-action_release/.github/workflows/main.yaml@v5
     with:
       publishToBinaries: true
       mavenCentralSync: true
       slackChannel: team-sonarqube-build
-  release_docker:
-    permissions:
-      id-token: write # Required by SonarSource/vault-action-wrapper
-      contents: write # Required by softprops/action-gh-release
-    runs-on: ubuntu-latest
-    name: Start Docker release process
-    needs: release
-    timeout-minutes: 60
-    steps:
-    - name: get secrets
-      id: secrets
-      uses: SonarSource/vault-action-wrapper@8e22afd670393ed80f489f5dbd517d09ea21d75b # 2.4.3-1
-      with:
-        secrets: |
-          development/github/token/SonarSource-sonar-scanner-cli-release token | GITHUB_TOKEN_RELEASE;
-          development/kv/data/slack token | SLACK_BOT_TOKEN;
-    - name: Notify failures on Slack
-      uses: slackapi/slack-github-action@v1.23.0
-      if: failure()
-      with:
-        channel-id: team-sonarqube-build
-        slack-message: "Releasing Docker Image failed, see the logs at https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }} by ${{ github.actor }}"
-      env:
-        SLACK_BOT_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).SLACK_BOT_TOKEN }}


### PR DESCRIPTION
- Update the release workflow to use the v5 branch for future updates
- Remove empty release_docker job