### PR TITLE
Update and lock plugins

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
   <groupId>org.sonarsource.scanner.cli</groupId>
   <artifactId>sonar-scanner-cli</artifactId>
-  <version>6.2-SNAPSHOT</version>
+  <version>${revision}</version>
   <packaging>jar</packaging>
   <name>SonarScanner CLI</name>
   <url>https://docs.sonarsource.com/sonarqube/latest/analyzing-source-code/scanners/sonarscanner/</url>
@@ -46,6 +46,8 @@
   </ciManagement>
 
   <properties>
+    <revision>6.2-SNAPSHOT</revision>
+
     <maven.test.redirectTestOutputToFile>true</maven.test.redirectTestOutputToFile>
 
     <!-- used for deployment to SonarSource Artifactory -->
@@ -95,7 +97,7 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-    <groupId>org.junit.jupiter</groupId>
+      <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-params</artifactId>
       <version>5.10.1</version>
       <scope>test</scope>
@@ -134,6 +136,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
+        <version>3.4.2</version>
         <configuration>
           <archive>
             <manifest>
@@ -147,7 +150,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>3.5.1</version>
+        <version>3.6.0</version>
         <executions>
           <execution>
             <phase>package</phase>
@@ -185,6 +188,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-assembly-plugin</artifactId>
+        <version>3.7.1</version>
         <executions>
           <execution>
             <id>cli</id>
@@ -210,6 +214,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
+        <version>3.5.0</version>
         <executions>
           <execution>
             <id>enforce-distribution-size</id>
@@ -234,13 +239,15 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
+        <version>3.8.0</version>
         <configuration>
-      	  <source>17</source>
+          <source>17</source>
         </configuration>
       </plugin>
       <plugin>
         <groupId>org.cyclonedx</groupId>
         <artifactId>cyclonedx-maven-plugin</artifactId>
+        <version>2.8.0</version>
         <executions>
           <execution>
             <phase>package</phase>
@@ -260,7 +267,7 @@
         <plugins>
           <plugin>
             <groupId>com.googlecode.maven-download-plugin</groupId>
-	          <artifactId>download-maven-plugin</artifactId>
+            <artifactId>download-maven-plugin</artifactId>
             <executions>
               <execution>
                 <id>unpack-linux-x64</id>
@@ -308,7 +315,7 @@
         <plugins>
           <plugin>
             <groupId>com.googlecode.maven-download-plugin</groupId>
-	          <artifactId>download-maven-plugin</artifactId>
+            <artifactId>download-maven-plugin</artifactId>
             <executions>
               <execution>
                 <id>unpack-linux-aarch64</id>


### PR DESCRIPTION
Updating and locking all plugins in the `pom.xml`. This increases the reproducibility of builds.

Also setting the project version with the `revision` property (see [Maven CI Friendly Versions](https://maven.apache.org/maven-ci-friendly.html)). This lets Maven commands override the package version (useful in CI jobs for release). For example:

```shell
mvn -Drevision 6.2.0.0000 clean package
```

---

We're currently updating the `sonar-scanner-cli` package in Nixpkgs, the main package repository for Nix (think of this as a Unix package manager like `apt`, `dnf`, `yum`, `pacman`, or `brew` that's portable and focused on reproducibility. Also doubles as a build system).

https://github.com/NixOS/nixpkgs/pull/329764

To ensure reproducibility when building this project from source, we're patching the `pom.xml` file downstream to lock all plugin versions.

Looking to upstream these patches to improve the reproducibility of this repository (irrespective of the Nix use case) and to remove brittle downstream patches.

Use of the `revision` property will also let SonarSource CI jobs and the Nixpkgs build control the path of the `maven-assembly-plugin`'s `target/sonar-scanner-${project.version}.zip` file dynamically.

This is more desirable than the current solution where we need to invoke `mvn org.apache.maven.plugins:maven-help-plugin:3.4.1:evaluate -Dexpression=project.version -DforceStdout --quiet` to get the project version since Maven has no built-in way to get the project version (requires a plugin).