### PR TITLE
Use shell alternative to `which`

### DIFF
--- a/src/main/assembly/bin/sonar-scanner
+++ b/src/main/assembly/bin/sonar-scanner
@@ -48,7 +48,7 @@ if [ -n "$JAVA_HOME" ]
 then
   java_cmd="$JAVA_HOME/bin/java"
 else
-  java_cmd="`which java`"
+  java_cmd="`\\unset -f command; \\command -v java`"
 fi
 
 if [ -z "$java_cmd" -o ! -x "$java_cmd" ] ; then


### PR DESCRIPTION
`which` may or may not be available on host systems. There are equivalent which are shell builtin.

This is essentially using the same as https://github.com/apache/maven/commit/8852b87412c0af70efcee76f1bb12bc44635aab1, which has proven to work fine on a large shell variety.
Also: https://pubs.opengroup.org/onlinepubs/009695399/utilities/command.html

Please be aware that we are not actively looking for feature contributions. The truth is that it's extremely difficult for someone outside SonarSource to comply with our roadmap and expectations. Therefore, we typically only accept minor cosmetic changes and typo fixes. If you would like to see a new feature, please create a new thread in the forum ["Suggest new features"](https://community.sonarsource.com/c/suggestions/features).

With that in mind, if you would like to submit a code contribution, make sure that you adhere to the following guidelines and all tests are passing:

- [X] Please explain your motives to contribute this change: what problem you are trying to fix, what improvement you are trying to make
- [X] Use the following formatting style: [SonarSource/sonar-developer-toolset](https://github.com/SonarSource/sonar-developer-toolset#code-style)
- [ ] Provide a unit test for any code you changed
- [ ] If there is a [JIRA](http://jira.sonarsource.com/browse/SCANCLI) ticket available, please make your commits and pull request start with the ticket ID (SCANCLI-XXXX)

We will try to give you feedback on your contribution as quickly as possible.

Thank You!
The SonarSource Team
