### PR TITLE
SCANCLI-162 Update embedded JRE to 17.0.12_7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,9 +55,9 @@
     <!-- configuration for assembly of distributions -->
     <unpack.dir>${project.build.directory}/unpack</unpack.dir>
     <scanner.jar>${project.build.finalName}.jar</scanner.jar>
-    <jre.dirname.linux>jdk-17.0.12+7-jre</jre.dirname.linux>
-    <jre.dirname.windows>jdk-17.0.12+7-jre</jre.dirname.windows>
-    <jre.dirname.macosx>jdk-17.0.12+7-jre/Contents/Home</jre.dirname.macosx>
+    <jre.dirname.linux>jdk-17.0.13+11-jre</jre.dirname.linux>
+    <jre.dirname.windows>jdk-17.0.13+11-jre</jre.dirname.windows>
+    <jre.dirname.macosx>jdk-17.0.13+11-jre/Contents/Home</jre.dirname.macosx>
 
     <!-- Release: enable publication to Bintray -->
     <artifactsToPublish>${project.groupId}:${project.artifactId}:zip,${project.groupId}:${project.artifactId}:zip:linux-x64,${project.groupId}:${project.artifactId}:zip:linux-aarch64,${project.groupId}:${project.artifactId}:zip:windows-x64,${project.groupId}:${project.artifactId}:zip:macosx-x64,${project.groupId}:${project.artifactId}:zip:macosx-aarch64,${project.groupId}:${project.artifactId}:json:cyclonedx</artifactsToPublish>
@@ -289,10 +289,10 @@
                   <goal>wget</goal>
                 </goals>
                 <configuration>
-                  <url>https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.12%2B7/OpenJDK17U-jre_x64_linux_hotspot_17.0.12_7.tar.gz</url>
+                  <url>https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.13%2B11/OpenJDK17U-jre_x64_linux_hotspot_17.0.13_11.tar.gz</url>
                   <unpack>true</unpack>
                   <outputDirectory>${unpack.dir}/linux-x64</outputDirectory>
-                  <sha256>0e8088d7a3a7496faba7ac8787db09dc0264c2bc6f568ea8024fd775a783e13c</sha256>
+                  <sha256>4086cc7cb2d9e7810141f255063caad10a8a018db5e6b47fa5394c506ab65bff</sha256>
                 </configuration>
               </execution>
             </executions>
@@ -337,10 +337,10 @@
                   <goal>wget</goal>
                 </goals>
                 <configuration>
-                  <url>https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.12%2B7/OpenJDK17U-jre_aarch64_linux_hotspot_17.0.12_7.tar.gz</url>
+                  <url>https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.13%2B11/OpenJDK17U-jre_aarch64_linux_hotspot_17.0.13_11.tar.gz</url>
                   <unpack>true</unpack>
                   <outputDirectory>${unpack.dir}/linux-aarch64</outputDirectory>
-                  <sha256>9dfe4c56463690ae67d22268980d8861eb46b907d7914f8f2e6fc7b25778c8ec</sha256>
+                  <sha256>97c4fb748eaa1292fb2f28fec90a3eba23e35974ef67f8b3aa304ad4db2ba162</sha256>
                 </configuration>
               </execution>
             </executions>
@@ -385,10 +385,10 @@
                   <goal>wget</goal>
                 </goals>
                 <configuration>
-                  <url>https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.12%2B7/OpenJDK17U-jre_x64_windows_hotspot_17.0.12_7.zip</url>
+                  <url>https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.13%2B11/OpenJDK17U-jre_x64_windows_hotspot_17.0.13_11.zip</url>
                   <unpack>true</unpack>
                   <outputDirectory>${unpack.dir}/windows-x64</outputDirectory>
-                  <sha256>646f1f60286670da309b586d0905f1df1a5c2f674d24006823d688bca65388f4</sha256>
+                  <sha256>11a61a94d383e755b08b4e5890a13d148bc9f95b7149cbbeec62efb8c75a4a67</sha256>
                 </configuration>
               </execution>
             </executions>
@@ -433,10 +433,10 @@
                   <goal>wget</goal>
                 </goals>
                 <configuration>
-                  <url>https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.12%2B7/OpenJDK17U-jre_x64_mac_hotspot_17.0.12_7.tar.gz</url>
+                  <url>https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.13%2B11/OpenJDK17U-jre_x64_mac_hotspot_17.0.13_11.tar.gz</url>
                   <unpack>true</unpack>
                   <outputDirectory>${unpack.dir}/macosx-x64</outputDirectory>
-                  <sha256>331aceddc402263c5e47529234965927573ead684ea2b7a0358fbb6c279c1510</sha256>
+                  <sha256>bf9faf4540001a251e6bfb52b99c7ec5b1f36d3ebe94e104f61a30f173ba8c78</sha256>
                 </configuration>
               </execution>
             </executions>
@@ -481,10 +481,10 @@
                   <goal>wget</goal>
                 </goals>
                 <configuration>
-                  <url>https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.12%2B7/OpenJDK17U-jre_aarch64_mac_hotspot_17.0.12_7.tar.gz</url>
+                  <url>https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.13%2B11/OpenJDK17U-jre_aarch64_mac_hotspot_17.0.13_11.tar.gz</url>
                   <unpack>true</unpack>
                   <outputDirectory>${unpack.dir}/macosx-aarch64</outputDirectory>
-                  <sha256>5c1cb2cbd2ef3f2b529e2733d0ab55381e10c4c3607f4d62f2bf12f0942198bf</sha256>
+                  <sha256>a886b8f2a50eca2e59b45ea59f5a2e8e9d27ff5b5b3b069443a70cda7f27c907</sha256>
                 </configuration>
               </execution>
             </executions>


### PR DESCRIPTION
[SCANCLI-162](https://sonarsource.atlassian.net/browse/SCANCLI-162)



[SCANCLI-162]: https://sonarsource.atlassian.net/browse/SCANCLI-162?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ