### PR TITLE
SCANCLI-148 Support non Latin characters in scanner properties.

### DIFF
--- a/src/test/java/org/sonarsource/scanner/cli/ConfTest.java
+++ b/src/test/java/org/sonarsource/scanner/cli/ConfTest.java
@@ -289,4 +289,13 @@ class ConfTest {
     assertThat(properties).containsEntry("sonar.prop", "expected");
   }
 
+  @Test
+  void should_handle_non_latin_characters() throws Exception  {
+    Path home = Paths.get(getClass().getResource("ConfTest/shouldHandleNonLatinChars/project").toURI());
+    args.setProperty("project.home", home.toAbsolutePath().toString());
+
+    Properties properties = conf.properties();
+    assertThat(properties).containsEntry("project.nonlatin", "Non Latin ÇŞĞIİÖÜ");
+  }
+
 }

--- a/src/test/resources/org/sonarsource/scanner/cli/ConfTest/shouldHandleNonLatinChars/project/sonar-project.properties
+++ b/src/test/resources/org/sonarsource/scanner/cli/ConfTest/shouldHandleNonLatinChars/project/sonar-project.properties
@@ -1,0 +1,1 @@
+project.nonlatin=Non Latin ÇŞĞIİÖÜ


### PR DESCRIPTION
[SCANCLI-148](https://sonarsource.atlassian.net/browse/SCANCLI-148)



[SCANCLI-148]: https://sonarsource.atlassian.net/browse/SCANCLI-148?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ