### PR TITLE
SCANCLI-218 Upgrade sonar-scanner-java-library to 4.1.1.1633

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
     <dependency>
       <groupId>org.sonarsource.scanner.lib</groupId>
       <artifactId>sonar-scanner-java-library</artifactId>
-      <version>4.1.0.1619</version>
+      <version>4.1.1.1633</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
@@ -242,8 +242,8 @@
             <configuration>
               <rules>
                 <requireFilesSize>
-                  <minsize>8800000</minsize>
-                  <maxsize>8900000</maxsize>
+                  <minsize>9200000</minsize>
+                  <maxsize>9300000</maxsize>
                   <files>
                     <file>${project.build.directory}/sonar-scanner-${project.version}.zip</file>
                   </files>


### PR DESCRIPTION
The new version of the library upgraded BouncyCastle from 1.83 to 1.84.

The size of that library increased significantly between those 2 versions (8.3 MB to 8.9 MB), causing the same increase in size of the Scanner CLI package. 

<!-- 
  Only for standalone PRs without Jira issue in the PR title: 
    * Replace this comment with Epic ID to create a new Task in Jira
    * Replace this comment with Issue ID to create a new Sub-Task in Jira
    * Ignore or delete this note to create a new Task in Jira without a parent 
-->

