### PR TITLE
SCANCLI-222 Change Code Owners and Slack notification

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,3 @@
-.github/CODEOWNERS @sonarsource/quality-processing-squad
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+* @sonarsource/code-quality-ci-experience-squad

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,4 +14,4 @@ jobs:
     with:
       publishToBinaries: true
       mavenCentralSync: true
-      slackChannel: ops-analysis-experience
+      slackChannel: ops-ci-experience


### PR DESCRIPTION
----
## Summary by Gitar

- **Configuration updates:**
  - Updated `.github/CODEOWNERS` to assign the `code-quality-ci-experience-squad` as owner.
  - Changed `slackChannel` in `.github/workflows/release.yml` from `ops-analysis-experience` to `ops-ci-experience`.

<sub>This will update automatically on new commits.</sub>